### PR TITLE
Fix: update macOS Snowgant config to correctly set running processes …

### DIFF
--- a/macos/snowagent.config
+++ b/macos/snowagent.config
@@ -41,8 +41,6 @@
         <Level>verbose</Level>
     </Logging>
     <SystemSettings>
-        <!-- Running processes -->
-        <Setting key="software.scan.running_processes" value="true"/>
         <!-- Scan jar files metadata -->
         <Setting key="software.scan.jar" value="true"/>
         <!-- Check for server certificate -->


### PR DESCRIPTION
The software.scan.running_processes functionality is specifically designed for Linux and Unix agents and does not apply to macOS agents. To maintain compatibility, the running processes setting in the Snowgant configuration file has been removed.
